### PR TITLE
Add Zillow Bridge API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Variáveis de ambiente exemplo
+
+# Token da Zillow Bridge API
+ZILLOW_BRIDGE_TOKEN=SEU_TOKEN_AQUI
+
+# URI do MongoDB
+MONGODB_URI=mongodb://localhost/zillowflip
+
+# Chave da OpenAI (opcional para insights)
+OPENAI_KEY=sua_openai_key

--- a/README.md
+++ b/README.md
@@ -46,8 +46,14 @@ cd zillowflip-ai
 # Instale as dependências
 npm install
 
-# Crie um .env com sua chave da OpenAI e dados do Zillow
+# Copie o arquivo de exemplo e defina suas chaves
 cp .env.example .env
+# Edite `.env` e preencha `ZILLOW_BRIDGE_TOKEN`, `MONGODB_URI` e `OPENAI_KEY`
 
 # Rode o servidor
 npm run dev
+
+## 📡 Endpoints
+
+- `GET /api/properties` lista propriedades filtrando por `city`, `state`, `minPrice` e `maxPrice`.
+- `GET /api/properties/:zpid` detalhes completos de uma propriedade.

--- a/routes/insights.js
+++ b/routes/insights.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+// Rota placeholder de insights
+router.get('/', (req, res) => {
+  res.json({ message: 'Insights endpoint em construção' });
+});
+
+module.exports = router;

--- a/routes/properties.js
+++ b/routes/properties.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+const { searchProperties, getPropertyDetails } = require('../services/zillow');
+
+router.get('/', async (req, res, next) => {
+  try {
+    const { city, state, minPrice, maxPrice } = req.query;
+    const props = await searchProperties({ city, state, minPrice, maxPrice });
+    res.json(props);
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.get('/:zpid', async (req, res, next) => {
+  try {
+    const { zpid } = req.params;
+    const details = await getPropertyDetails(zpid);
+    res.json(details);
+  } catch (e) {
+    next(e);
+  }
+});
+
+module.exports = router;

--- a/services/zillow.js
+++ b/services/zillow.js
@@ -1,0 +1,29 @@
+const axios = require('axios');
+
+const BRIDGE_BASE = 'https://api.bridgeinteractive.com';
+const TOKEN = process.env.ZILLOW_BRIDGE_TOKEN;
+
+if (!TOKEN) {
+  throw new Error('⚠️ Defina ZILLOW_BRIDGE_TOKEN no seu .env');
+}
+
+async function getPropertyDetails(zpid) {
+  const res = await axios.get(
+    `${BRIDGE_BASE}/bridge/v1/property/${zpid}`,
+    { headers: { Authorization: `Bearer ${TOKEN}` } }
+  );
+  return res.data;
+}
+
+async function searchProperties({ city, state, minPrice, maxPrice }) {
+  const res = await axios.get(
+    `${BRIDGE_BASE}/bridge/v1/listings`,
+    {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+      params: { city, state, minPrice, maxPrice }
+    }
+  );
+  return res.data;
+}
+
+module.exports = { getPropertyDetails, searchProperties };


### PR DESCRIPTION
## Summary
- integrate official Zillow Bridge API
- expose property routes for search & details
- add placeholder insights route
- document environment variables and endpoints

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687c161e78848323a57ad634aaa2936b